### PR TITLE
Redirect from login if authed

### DIFF
--- a/src/app/main/main.controller.js
+++ b/src/app/main/main.controller.js
@@ -8,10 +8,13 @@
 
     /** @ngInject */
     
-    function MainController($anchorScroll, $location, $scope, $state, TokenService) {
+    function MainController($anchorScroll, $location, $scope, $state, TokenService, AuthService) {
         var vm = this;
 
-        if (TokenService.getToken() && TokenService.getUser()) {
+        // if a 401 Unauthorized response is returned, then the token and user are 
+        // cleared from local storage. This ensures that the user won't fall into an
+        // infinite loop! If they are already authed, just redirect to discover
+        if (TokenService.getToken() && AuthService.getUser()) {
           return $state.go('dashboard.discover');
         }
 

--- a/src/app/main/main.controller.js
+++ b/src/app/main/main.controller.js
@@ -8,8 +8,12 @@
 
     /** @ngInject */
     
-    function MainController($anchorScroll, $location, $scope) {
+    function MainController($anchorScroll, $location, $scope, $state, TokenService) {
         var vm = this;
+
+        if (TokenService.getToken() && TokenService.getUser()) {
+          return $state.go('dashboard.discover');
+        }
 
         $scope.gotoExplore = function(){
             if($location.hash() !== 'explore') {

--- a/src/app/services/tokenService.js
+++ b/src/app/services/tokenService.js
@@ -16,6 +16,7 @@ angular
 
         clearToken: function() {
           localStorageService.remove('token');
+          localStorageService.remove('user');
         },
 
         onUnauthorized: function() {


### PR DESCRIPTION
this checks for an auth token and a user object. If both are missing, then the user is redirected to the discover page.

If, for some reason, the token is invalid (and 401 unauthorized is returned), the token and user object will be cleared and the user will be redirected back to the login page.