### PR TITLE
Fix/search result redirect

### DIFF
--- a/src/app/components/jamjarPlayer/jamjarPlayer.html
+++ b/src/app/components/jamjarPlayer/jamjarPlayer.html
@@ -59,7 +59,7 @@
       <div layout="column" layout-align="center start">
         <div class="primary-video-title">Title: {{player.jamjar.primaryVideo.video.name}}</div>
         <div class="user-info">
-            Uploaded by <a ui-sref="dashboard.explore({uploaders: video.user.id})">{{player.jamjar.primaryVideo.video.user.username}}</a>
+            Uploaded by <a ui-sref="dashboard.explore({uploaders: video.user.id, name: video.user.username})">{{player.jamjar.primaryVideo.video.user.username}}</a>
         </div>
       </div>
     </div>

--- a/src/app/components/navbar/navbar.directive.js
+++ b/src/app/components/navbar/navbar.directive.js
@@ -64,14 +64,35 @@
         };
         
         vm.searchText = "";
+        vm.selectedItem = null;
 
         vm.querySearch  = function(query) {
           var promise = SearchService.search(vm.searchText);
           return promise;
         }
 
+        vm.searchResultClick = function() {
+          if (!vm.selectedItem) return;
+
+          var type = vm.selectedItem.type;
+
+          if (type == 'user') {
+            $state.go('dashboard.explore', {uploaders: vm.selectedItem.id});
+          } else if (type == 'video') {
+            $state.go('dashboard.player', {concert_id: vm.selectedItem.concert_id, video_id: vm.selectedItem.id, type:'individual'});
+          } else if (type == 'concert') {
+            $state.go('dashboard.concert', {id: vm.selectedItem.id});
+          } else if (type == 'artist') {
+            $state.go('dashboard.explore', {artists: vm.selectedItem.id});
+          } else if (type == 'venue') {
+            $state.go('dashboard.explore', {venues: vm.selectedItem.id});
+          } else {
+            console.error("unsupported search type:", type);
+          }
+        }
+
         vm.allPages = vm.pages.concat(vm.settings);
-        
+
         var originatorEv;
 
         vm.openMenu = function($mdOpenMenu, ev) {

--- a/src/app/components/navbar/navbar.directive.js
+++ b/src/app/components/navbar/navbar.directive.js
@@ -77,15 +77,15 @@
           var type = vm.selectedItem.type;
 
           if (type == 'user') {
-            $state.go('dashboard.explore', {uploaders: vm.selectedItem.id});
+            $state.go('dashboard.explore', {uploaders: vm.selectedItem.id, name: vm.selectedItem.name}, {inherit: false});
           } else if (type == 'video') {
             $state.go('dashboard.player', {concert_id: vm.selectedItem.concert_id, video_id: vm.selectedItem.id, type:'individual'});
           } else if (type == 'concert') {
             $state.go('dashboard.concert', {id: vm.selectedItem.id});
           } else if (type == 'artist') {
-            $state.go('dashboard.explore', {artists: vm.selectedItem.id});
+            $state.go('dashboard.explore', {artists: vm.selectedItem.id, name: vm.selectedItem.name}, {inherit: false});
           } else if (type == 'venue') {
-            $state.go('dashboard.explore', {venues: vm.selectedItem.id});
+            $state.go('dashboard.explore', {venues: vm.selectedItem.id, name: vm.selectedItem.name}, {inherit: false});
           } else {
             console.error("unsupported search type:", type);
           }

--- a/src/app/components/navbar/navbar.html
+++ b/src/app/components/navbar/navbar.html
@@ -7,10 +7,11 @@
         <span flex>
             <form name="searchBar" ng-submit="$event.preventDefault()">
               <md-autocomplete class='navbar-search'
-                  md-search-text-change=""
+                  md-selected-item-change="vm.searchResultClick()"
+                  md-selected-item="vm.selectedItem"
                   md-search-text="vm.searchText"
                   md-items="item in vm.querySearch(vm.searchText)"
-                  md-item-text="item"
+                  md-item-text="item.name"
                   md-min-length="1"
                   md-menu-class="navbar-search-results"
                   placeholder="Search...">

--- a/src/app/dashboard/concert/concert.html
+++ b/src/app/dashboard/concert/concert.html
@@ -52,7 +52,7 @@
           <img ng-src="{{video.thumb_src[256]}}" class="rect thumbnail"/>
           <h3>{{video.name}}</h3>
         </a>
-        <h4>Uploader: <a ui-sref="dashboard.explore({uploaders: video.user.id})">{{video.user.username}}</a></h4>
+        <h4>Uploader: <a ui-sref="dashboard.explore({uploaders: video.user.id, name: video.user.username})">{{video.user.username}}</a></h4>
         <h4>Views: {{video.views}}</h4>
       </div>
     </div>

--- a/src/app/dashboard/discover/genres.html
+++ b/src/app/dashboard/discover/genres.html
@@ -3,7 +3,7 @@
 <div layout="row" layout-align="start start" layout-wrap class='genres-section'>
   <div ng-repeat="genre in vm.genres" flex-xs="100" flex-sm="50" flex-md="25" flex-gt-md="20">
     <div layout="column" class="block">
-      <a ui-sref="dashboard.explore({genres: genre.id})">
+      <a ui-sref="dashboard.explore({genres: genre.id, name: genre.name})">
         <div class='rect genre' ng-style="vm.getGenreStyles($index)">
           <div class='genre-text'>{{ genre.name }}</div>
         </div>

--- a/src/app/dashboard/explore/explore.controller.js
+++ b/src/app/dashboard/explore/explore.controller.js
@@ -16,18 +16,14 @@
       'venues'   : $stateParams.venues
     };
 
-    vm.genrename = '';
     vm.videos = [];
     vm.concerts = [];
-    vm.venues = [];
+
+    vm.name = $stateParams.name;
 
     VideoService.getVideos(vm.query, function(err, resp) {
       vm.videos = resp;
       vm.concerts = _.uniqBy(_.map(resp, 'concert'), 'id');
-    });
-    
-    GenreService.list(function(err, resp) {
-        vm.genrename = _.find(resp, {id: parseInt($stateParams.genres)}).name;
     });
   }
 

--- a/src/app/dashboard/explore/explore.controller.js
+++ b/src/app/dashboard/explore/explore.controller.js
@@ -12,12 +12,14 @@
     vm.query = {
       'genres'  : $stateParams.genres,
       'artists' : $stateParams.artists,
-      'uploaders'   : $stateParams.uploaders
+      'uploaders'   : $stateParams.uploaders,
+      'venues'   : $stateParams.venues
     };
 
     vm.genrename = '';
     vm.videos = [];
     vm.concerts = [];
+    vm.venues = [];
 
     VideoService.getVideos(vm.query, function(err, resp) {
       vm.videos = resp;

--- a/src/app/dashboard/explore/explore.html
+++ b/src/app/dashboard/explore/explore.html
@@ -2,7 +2,7 @@
     
   <div layout="row" class="genre-banner small-padding">
     <div class="genre-banner-bg"></div>
-    <h1>Explore: <span class="genre-name">{{vm.genrename}}</span></h1>
+    <h1>Explore: <span class="genre-name">{{vm.name}}</span></h1>
   </div>
 
   <div layout="row" class="concert-section">
@@ -63,7 +63,7 @@
             {{$last ? '' : ', '}}
           </span>
         </h3>
-        <h4>Uploader: <a ui-sref="dashboard.explore({uploaders: video.user.id})">{{video.user.username}}</a></h4>
+        <h4>Uploader: <a ui-sref="dashboard.explore({uploaders: video.user.id, name: video.user.username})" ui-sref-opts="{inherit: false}">{{video.user.username}}</a></h4>
         <h4>Views: {{video.views}}</h4>
       </div>
     </div>

--- a/src/app/index.route.js
+++ b/src/app/index.route.js
@@ -34,7 +34,7 @@
         controllerAs: 'vm'
       })
       .state('dashboard.explore', {
-        url: '/explore?genres?artists?uploaders',
+        url: '/explore?genres?artists?uploaders?venues',
         templateUrl: 'app/dashboard/explore/explore.html',
         controller: 'ExploreController',
         controllerAs: 'vm'

--- a/src/app/index.route.js
+++ b/src/app/index.route.js
@@ -34,7 +34,7 @@
         controllerAs: 'vm'
       })
       .state('dashboard.explore', {
-        url: '/explore?genres?artists?uploaders?venues',
+        url: '/explore?genres?artists?uploaders?venues?name',
         templateUrl: 'app/dashboard/explore/explore.html',
         controller: 'ExploreController',
         controllerAs: 'vm'

--- a/src/app/services/searchService.js
+++ b/src/app/services/searchService.js
@@ -45,6 +45,7 @@ function handleArtist(artist) {
   return {
     type: 'artist',
     icon: 'mic',
+    id: artist.id,
     name: artist.name,
     details: null
   }

--- a/src/app/services/searchService.js
+++ b/src/app/services/searchService.js
@@ -5,6 +5,7 @@ function handleVenue(venue) {
     type: 'venue',
     icon: 'home',
     name: venue.name,
+    id: venue.id,
     details: venue.formatted_address,
   }
 }
@@ -14,6 +15,7 @@ function handleUser(user) {
     type: 'user',
     icon: 'person',
     name: user.username,
+    id: user.id,
     details: null
   }
 }
@@ -23,6 +25,8 @@ function handleVideo(video) {
     type: 'video',
     icon: 'videocam',
     name: video.name,
+    id: video.id,
+    concert_id: video.concert,
     details: 'Uploaded by ' + video.user.username
   }
 }
@@ -32,6 +36,7 @@ function handleConcert(concert) {
     type: 'concert',
     icon: 'local_play',
     name: concert.venue.name + ' on ' + concert.date,
+    id: concert.id,
     details: "Featuring " + _.map(concert.artists, 'name').join(", ")
   }
 }


### PR DESCRIPTION
This branch allows users to go to the results page (explore, concert, player, etc) after clicking a search result. Moreover, the label on the explore page is generated by the caller to save a request in the explore controller (given that the caller already has this information (which is does))