### PR TITLE
Fix/jamjarplayer

### DIFF
--- a/src/app/components/jamjarPlayer/jamjarOverlay.tmpl.html
+++ b/src/app/components/jamjarPlayer/jamjarOverlay.tmpl.html
@@ -3,7 +3,7 @@
     <div layout="column" class="jamjar-layer">
         <div class='jamjar-bar' ng-style="{'margin-left': video.presentation.offset}">
             <md-button layout="row" class="primary-video-btn">
-                <div flex class="jamjar-line past-jam" 
+                <div class="jamjar-line past-jam" 
                      ng-style="{width: player.jamjar.primaryVideo.presentation.doneWidth}"></div>
                 
                 <div class="ol-thumbnail-img" 
@@ -23,7 +23,7 @@
             <div ng-click="player.jamjar.handleSwitch(video)">
                 <div class='jamjar-bar' ng-style="{'margin-left': video.presentation.offset}">
                     <md-button layout="row" ng-class="{'disabled-jam-btn': !video.presentation.playable}">
-                        <div flex class='jamjar-line past-jam' 
+                        <div class='jamjar-line past-jam' 
                              ng-style="{width: video.presentation.doneWidth}" 
                              ng-show="video.presentation.playable"></div>
                         

--- a/src/app/components/jamjarPlayer/jamjarOverlay.tmpl.html
+++ b/src/app/components/jamjarPlayer/jamjarOverlay.tmpl.html
@@ -1,8 +1,10 @@
 <div ng-show='player.overlay.visible' class='jamjar-layer-bg-container'>
     <div class='jamjar-layer-bg'></div>
     <div layout="column" class="jamjar-layer">
-        <div class='jamjar-bar' ng-style="{'margin-left': video.presentation.offset}">
-            <md-button layout="row" class="primary-video-btn">
+        <div class='jamjar-bar'>
+            <md-button layout="row" class="primary-video-btn" 
+                       ng-style="{'margin-left': video.presentation.offset, 'padding-left': video.presentation.paddingOffset}">
+                
                 <div class="jamjar-line past-jam" 
                      ng-style="{width: player.jamjar.primaryVideo.presentation.doneWidth}"></div>
                 
@@ -21,8 +23,11 @@
 
         <div ng-repeat="video in player.jamjar.nowPlaying track by video.video.id" ng-if="video != player.jamjar.primaryVideo" >
             <div ng-click="player.jamjar.handleSwitch(video)">
-                <div class='jamjar-bar' ng-style="{'margin-left': video.presentation.offset}">
-                    <md-button layout="row" ng-class="{'disabled-jam-btn': !video.presentation.playable}">
+                <div class='jamjar-bar'>
+                    <md-button layout="row" 
+                            ng-class="{'disabled-jam-btn': !video.presentation.playable}"
+                            ng-style="{'margin-left': video.presentation.offset, 'padding-left': video.presentation.paddingOffset}">
+                        
                         <div class='jamjar-line past-jam' 
                              ng-style="{width: video.presentation.doneWidth}" 
                              ng-show="video.presentation.playable"></div>

--- a/src/app/components/jamjarPlayer/jamjarOverlay.tmpl.html
+++ b/src/app/components/jamjarPlayer/jamjarOverlay.tmpl.html
@@ -16,7 +16,7 @@
                      ng-style="{width: player.jamjar.primaryVideo.presentation.width}"></div>
                 
                 <md-tooltip>
-                    <div flex>'{{player.jamjar.primaryVideo.video.name}}' uploaded by {{player.jamjar.primaryVideo.video.user.username}}</div>
+                    <div flex><b>NOW PLAYING:</b> '{{player.jamjar.primaryVideo.video.name}}' uploaded by {{player.jamjar.primaryVideo.video.user.username}}</div>
                 </md-tooltip>
             </md-button>
         </div>

--- a/src/app/components/jamjarPlayer/jamjarOverlay.tmpl.html
+++ b/src/app/components/jamjarPlayer/jamjarOverlay.tmpl.html
@@ -1,12 +1,18 @@
 <div ng-show='player.overlay.visible' class='jamjar-layer-bg-container'>
     <div class='jamjar-layer-bg'></div>
     <div layout="column" class="jamjar-layer">
-        <div class='jamjar-bar'>
+        <div class='jamjar-bar' ng-style="{'margin-left': video.presentation.offset}">
             <md-button layout="row" class="primary-video-btn">
+                <div flex class="jamjar-line past-jam" 
+                     ng-style="{width: player.jamjar.primaryVideo.presentation.doneWidth}"></div>
+                
                 <div class="ol-thumbnail-img" 
                      ng-style="{'background-image':'url('+player.jamjar.primaryVideo.video.thumb_src[128]+')'}">
                 </div>
-                <div flex class="jamjar-line active-jam" ng-style="{width: player.jamjar.primaryVideo.presentation.width}"></div>
+                
+                <div flex class="jamjar-line active-jam" 
+                     ng-style="{width: player.jamjar.primaryVideo.presentation.width}"></div>
+                
                 <md-tooltip>
                     <div flex>'{{player.jamjar.primaryVideo.video.name}}' uploaded by {{player.jamjar.primaryVideo.video.user.username}}</div>
                 </md-tooltip>
@@ -17,12 +23,20 @@
             <div ng-click="player.jamjar.handleSwitch(video)">
                 <div class='jamjar-bar' ng-style="{'margin-left': video.presentation.offset}">
                     <md-button layout="row" ng-class="{'disabled-jam-btn': !video.presentation.playable}">
+                        <div flex class='jamjar-line past-jam' 
+                             ng-style="{width: video.presentation.doneWidth}" 
+                             ng-show="video.presentation.playable"></div>
+                        
                         <div class="ol-thumbnail-img" 
                              ng-style="{'background-image':'url('+video.video.thumb_src[128]+')'}">
                         </div>
-                        <div flex class='jamjar-line' ng-style="{width: video.presentation.width}" ng-class="{'disabled-jam': !video.presentation.playable}"></div>
+                        
+                        <div flex class='jamjar-line' 
+                             ng-style="{width: video.presentation.width}" 
+                             ng-class="{'disabled-jam': !video.presentation.playable}"></div>
+                        
                         <md-tooltip>
-                        <div flex>'{{video.video.name}}' uploaded by {{video.video.user.username}}</div>
+                            <div flex>'{{video.video.name}}' uploaded by {{video.video.user.username}}</div>
                         </md-tooltip>
                     </md-button>
                 </div>

--- a/src/app/components/jamjarPlayer/jamjarPlayer.directive.js
+++ b/src/app/components/jamjarPlayer/jamjarPlayer.directive.js
@@ -186,7 +186,7 @@
     self.presentation = {
       offset: '0px',
       doneWidth: '0px',
-      paddingOffset: '100px',
+      paddingOffset: '0px',
       width: '0px',
       playable: false,
       preload: 'none',
@@ -198,14 +198,15 @@
   Video.prototype.updatePresentationDetails = function(primaryVideo, edgeToPrimary) {
     var self = this;
 
+    var maxWidthOfPastBar = 100; //class: past-jam
+      
     var offset = self.calcOffsetMargin(primaryVideo, edgeToPrimary);
-    self.presentation.offset = (offset) + 'px';
-    //console.log("TIME:" + self.time());
-    
-    self.presentation.doneWidth = (self.time()) + "px";
-    self.presentation.paddingOffset = (100 - self.time()) + "px";
-        
+    self.presentation.offset = (offset) + 'px';    
     self.presentation.width  = (self.video.length - self.time()) + "px";
+      
+    self.presentation.paddingOffset = (maxWidthOfPastBar - self.time()) + "px";
+    self.presentation.doneWidth = (self.time()) + "px";
+      
     self.presentation.playable = (offset == 0);
 
     if (self.presentation.playable) {

--- a/src/app/components/jamjarPlayer/jamjarPlayer.directive.js
+++ b/src/app/components/jamjarPlayer/jamjarPlayer.directive.js
@@ -198,7 +198,7 @@
     var self = this;
 
     var offset = self.calcOffsetMargin(primaryVideo, edgeToPrimary);
-    self.presentation.offset = (offset) + 'px';
+    self.presentation.offset = (offset + 100) + 'px';
     //console.log("TIME:" + self.time());
     self.presentation.doneWidth = (self.time()) + "px";
     self.presentation.width  = (self.video.length - self.time()) + "px";

--- a/src/app/components/jamjarPlayer/jamjarPlayer.directive.js
+++ b/src/app/components/jamjarPlayer/jamjarPlayer.directive.js
@@ -185,6 +185,7 @@
 
     self.presentation = {
       offset: '0px',
+      doneWidth: '0px',
       width: '0px',
       playable: false,
       preload: 'none',
@@ -197,8 +198,10 @@
     var self = this;
 
     var offset = self.calcOffsetMargin(primaryVideo, edgeToPrimary);
-    self.presentation.offset = 10 * offset + 'px';
-    self.presentation.width  = 10 * (self.video.length - self.time()) + "px"
+    self.presentation.offset = (offset) + 'px';
+    //console.log("TIME:" + self.time());
+    self.presentation.doneWidth = (self.time()) + "px";
+    self.presentation.width  = (self.video.length - self.time()) + "px";
     self.presentation.playable = (offset == 0);
 
     if (self.presentation.playable) {

--- a/src/app/components/jamjarPlayer/jamjarPlayer.directive.js
+++ b/src/app/components/jamjarPlayer/jamjarPlayer.directive.js
@@ -186,6 +186,7 @@
     self.presentation = {
       offset: '0px',
       doneWidth: '0px',
+      paddingOffset: '100px',
       width: '0px',
       playable: false,
       preload: 'none',
@@ -198,9 +199,12 @@
     var self = this;
 
     var offset = self.calcOffsetMargin(primaryVideo, edgeToPrimary);
-    self.presentation.offset = (offset + 100) + 'px';
+    self.presentation.offset = (offset) + 'px';
     //console.log("TIME:" + self.time());
+    
     self.presentation.doneWidth = (self.time()) + "px";
+    self.presentation.paddingOffset = (100 - self.time()) + "px";
+        
     self.presentation.width  = (self.video.length - self.time()) + "px";
     self.presentation.playable = (offset == 0);
 

--- a/src/app/components/jamjarPlayer/jamjarPlayer.html
+++ b/src/app/components/jamjarPlayer/jamjarPlayer.html
@@ -1,9 +1,9 @@
 <div layout="column" class="theatre-bg">
   <div layout="column" ng-if="player.jamjar.primaryVideo"
-      class='jamjar-player videogular-container'
+      class='videogular-container'
       ng-mousemove="player.onHover($event)">
       <div ng-repeat="video in player.jamjar.nowPlaying track by video.video.id">
-        <videogular flex
+        <videogular
             vg-theme="player.config.theme"
             vg-auto-play="(video == player.jamjar.primaryVideo)"
             vg-player-ready="player.jamjar.onPlayerReady($API, video)"

--- a/src/app/components/jamjarPlayer/jamjarPlayer.scss
+++ b/src/app/components/jamjarPlayer/jamjarPlayer.scss
@@ -120,6 +120,8 @@ videogular div.jamjar-layer {
     cursor: not-allowed;
     min-width: 5px !important;
     max-width: 100px !important;
+    display: block;
+    float: right;
 }
 
 .primary-video-btn {

--- a/src/app/components/jamjarPlayer/jamjarPlayer.scss
+++ b/src/app/components/jamjarPlayer/jamjarPlayer.scss
@@ -1,26 +1,26 @@
-.jamjar-player {
-    background-color: #000;
-
-    .player-sidebar {
-        color: white;
-
-        .player-thumbnail {
-            max-width: 100%;
-            background: rgba(0,255,255, 0.5);
-        }
-
-        .player-thumbnail-info {
-            position:relative;
-            top:-30px;
-            height: 30px;
-            width: 100%;
-            color: white;
-            text-align: center;
-            line-height: 30px;
-            background-color: rgba(0,0,0,0.5)
-        }
-    }
-}
+//.jamjar-player {
+//    background-color: #000;
+//
+//    .player-sidebar {
+//        color: white;
+//
+//        .player-thumbnail {
+//            max-width: 100%;
+//            background: rgba(0,255,255, 0.5);
+//        }
+//
+//        .player-thumbnail-info {
+//            position:relative;
+//            top:-30px;
+//            height: 30px;
+//            width: 100%;
+//            color: white;
+//            text-align: center;
+//            line-height: 30px;
+//            background-color: rgba(0,0,0,0.5)
+//        }
+//    }
+//}
 
 .theatre-bg {
     background-color: #000;
@@ -81,12 +81,13 @@ videogular div.jamjar-layer {
 .jamjar-line {
     border-radius: 15px;
     padding: 2px;
-    margin: 5px 5px 5px -15px;
-    min-width: 100px;
-    height: 30px;
+    margin: 5px 5px 5px -6px;
+    min-width: 5px !important;
+    height: 15px;
     background: $green;
     cursor: pointer;
     z-index: 50;
+    opacity: .7;
 
     //-moz-transition: all 1s ease-out;     /* FF4+ */
     //-webkit-transition: all 1s ease-out;  /* Saf3.2+, Chrome */
@@ -113,6 +114,14 @@ videogular div.jamjar-layer {
     cursor: not-allowed !important;
 }
 
+.past-jam {
+    margin-right: -6px !important;
+    background: #2a2a2a;
+    cursor: not-allowed;
+    min-width: 5px !important;
+    max-width: 100px !important;
+}
+
 .primary-video-btn {
     cursor: not-allowed !important;
 }
@@ -128,6 +137,7 @@ videogular div.jamjar-layer {
     height              : 65px;
     border-radius       : 50%;
     z-index: 70;
+    opacity: 1;
 }
 
 

--- a/src/app/components/jamjarPlayer/jamjarPlayer.scss
+++ b/src/app/components/jamjarPlayer/jamjarPlayer.scss
@@ -60,7 +60,7 @@ videogular div.jamjar-layer-bg {
     position: absolute;
     top: 0;
     z-index: 4;
-    opacity: 0.4;
+    opacity: 0.5;
 }
 
 videogular div.jamjar-layer {
@@ -82,7 +82,7 @@ videogular div.jamjar-layer {
     border-radius: 15px;
     padding: 2px;
     margin: 5px 5px 5px -6px;
-    min-width: 5px !important;
+    min-width: 15px !important;
     height: 15px;
     background: $green;
     cursor: pointer;
@@ -110,7 +110,7 @@ videogular div.jamjar-layer {
 }
 
 .active-jam {
-    background: $coral !important;
+    background: $blue !important;
     cursor: not-allowed !important;
 }
 


### PR DESCRIPTION
I showed the jamjar player to a couple friends and the westphal professor, and one of the major things they were confused about was the movement of the bars and the relationship between them. I had to explain that we use the leftmost side of the video player as the point where videos overlap and become available to click on. 

To make this more intuitive, I added a 'past-bar' to show that we have moved through a specific part in the video sequence. Now, the user may be able to guess that when the thumbnails align, they become available to click on.

Let me know what you think or if you have a different idea!